### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ESPHome component to monitor a Lumentree Solar Inverter via BLE
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2024.12.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 board
 
 ## Installation

--- a/components/lumentree_ble/__init__.py
+++ b/components/lumentree_ble/__init__.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("30s"))
+    .extend(cv.polling_component_schema("30s")),
 )
 
 

--- a/components/lumentree_ble/__init__.py
+++ b/components/lumentree_ble/__init__.py
@@ -29,7 +29,8 @@ LUMENTREE_BLE_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LumentreeBle),

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-lumentree"
     version: 1.2.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-lumentree"
     version: 1.2.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -4,7 +4,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp32:
   board: esp32-c6-devkitc-1


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.