### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/lumentree_ble/button/__init__.py
+++ b/components/lumentree_ble/button/__init__.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = LUMENTREE_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_BATTERY_SETTINGS_RESET): button.button_schema(
             LumentreeButton,
             icon=ICON_BATTERY_SETTINGS_RESET,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/lumentree_ble/select/__init__.py
+++ b/components/lumentree_ble/select/__init__.py
@@ -25,7 +25,7 @@ CONFIG_SCHEMA = LUMENTREE_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_OPERATION_MODE): select.select_schema(
             LumentreeSelect,
             icon="mdi:cog",
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/lumentree_ble/switch/__init__.py
+++ b/components/lumentree_ble/switch/__init__.py
@@ -29,11 +29,11 @@ CONFIG_SCHEMA = LUMENTREE_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_AC_CHARGING): switch.switch_schema(
             LumentreeSwitch,
             icon=ICON_AC_CHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_OUTPUT): switch.switch_schema(
             LumentreeSwitch,
             icon=ICON_OUTPUT,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant