### PR TITLE
Use new_* API instead of deprecated register_* functions

### DIFF
--- a/components/lumentree_ble/button/__init__.py
+++ b/components/lumentree_ble/button/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import CONF_LUMENTREE_BLE_ID, LUMENTREE_BLE_COMPONENT_SCHEMA, lumentree_ble_ns
 
@@ -36,8 +35,7 @@ async def to_code(config):
     for key, address in BUTTONS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await button.new_button(conf)
             await cg.register_component(var, conf)
-            await button.register_button(var, conf)
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))

--- a/components/lumentree_ble/number/__init__.py
+++ b/components/lumentree_ble/number/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
     CONF_MODE,

--- a/components/lumentree_ble/number/__init__.py
+++ b/components/lumentree_ble/number/__init__.py
@@ -114,15 +114,13 @@ async def to_code(config):
     for key, address in NUMBERS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
-            await cg.register_component(var, conf)
-            await number.register_number(
-                var,
+            var = await number.new_number(
                 conf,
                 min_value=conf[CONF_MIN_VALUE],
                 max_value=conf[CONF_MAX_VALUE],
                 step=conf[CONF_STEP],
             )
+            await cg.register_component(var, conf)
             cg.add(getattr(hub, f"set_{key}_number")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address[0]))

--- a/components/lumentree_ble/select/__init__.py
+++ b/components/lumentree_ble/select/__init__.py
@@ -34,9 +34,7 @@ async def to_code(config):
     hub = await cg.get_variable(config[CONF_LUMENTREE_BLE_ID])
     if CONF_OPERATION_MODE in config:
         conf = config[CONF_OPERATION_MODE]
-        var = await select.new_select(
-            conf, options=list(OPERATION_MODE_OPTIONS.keys())
-        )
+        var = await select.new_select(conf, options=list(OPERATION_MODE_OPTIONS.keys()))
         await cg.register_component(var, conf)
         cg.add(var.set_parent(hub))
         cg.add(var.set_holding_register(150))  # Work Mode Setting register

--- a/components/lumentree_ble/select/__init__.py
+++ b/components/lumentree_ble/select/__init__.py
@@ -34,11 +34,10 @@ async def to_code(config):
     hub = await cg.get_variable(config[CONF_LUMENTREE_BLE_ID])
     if CONF_OPERATION_MODE in config:
         conf = config[CONF_OPERATION_MODE]
-        var = cg.new_Pvariable(conf[cv.CONF_ID])
-        await cg.register_component(var, conf)
-        await select.register_select(
-            var, conf, options=list(OPERATION_MODE_OPTIONS.keys())
+        var = await select.new_select(
+            conf, options=list(OPERATION_MODE_OPTIONS.keys())
         )
+        await cg.register_component(var, conf)
         cg.add(var.set_parent(hub))
         cg.add(var.set_holding_register(150))  # Work Mode Setting register
 

--- a/components/lumentree_ble/switch/__init__.py
+++ b/components/lumentree_ble/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_OUTPUT
+from esphome.const import CONF_OUTPUT
 
 from .. import CONF_LUMENTREE_BLE_ID, LUMENTREE_BLE_COMPONENT_SCHEMA, lumentree_ble_ns
 
@@ -43,9 +43,8 @@ async def to_code(config):
     for key, address in SWITCHES.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await switch.new_switch(conf)
             await cg.register_component(var, conf)
-            await switch.register_switch(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))


### PR DESCRIPTION
Replace deprecated `register_binary_sensor`/`register_switch`/`register_button`/`register_number`/`register_select` calls with the modern `new_*` API. The `new_*` functions internally call `cg.new_Pvariable()` + `register_*()`, reducing boilerplate. `register_component()` is kept separately for Component subclasses.