### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/lumentree_ble/binary_sensor.py
+++ b/components/lumentree_ble/binary_sensor.py
@@ -6,6 +6,7 @@ from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 from . import CONF_LUMENTREE_BLE_ID, LUMENTREE_BLE_COMPONENT_SCHEMA, lumentree_ble_ns
 
 DEPENDENCIES = ["lumentree_ble"]
+CODEOWNERS = ["@syssi"]
 
 CONF_GRID_CONNECTED = "grid_connected"
 CONF_BATTERY_CONNECTED = "battery_connected"

--- a/components/lumentree_ble/sensor.py
+++ b/components/lumentree_ble/sensor.py
@@ -25,6 +25,7 @@ from esphome.const import (
 from . import CONF_LUMENTREE_BLE_ID, LUMENTREE_BLE_COMPONENT_SCHEMA, lumentree_ble_ns
 
 DEPENDENCIES = ["lumentree_ble"]
+CODEOWNERS = ["@syssi"]
 
 # CONF_BATTERY_VOLTAGE = "battery_voltage"
 CONF_BATTERY_CURRENT = "battery_current"

--- a/components/lumentree_ble/text_sensor.py
+++ b/components/lumentree_ble/text_sensor.py
@@ -6,6 +6,7 @@ from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 from . import CONF_LUMENTREE_BLE_ID, LUMENTREE_BLE_COMPONENT_SCHEMA, lumentree_ble_ns
 
 DEPENDENCIES = ["lumentree_ble"]
+CODEOWNERS = ["@syssi"]
 
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_OPERATION_MODE = "operation_mode"


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `sensor.py`, `binary_sensor.py`, and `text_sensor.py` for consistency with other ESPHome components.