### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/lumentree_ble/lumentree_ble.h
+++ b/components/lumentree_ble/lumentree_ble.h
@@ -216,7 +216,7 @@ class LumentreeBle : public esphome::ble_client::BLEClientNode, public PollingCo
 
   select::Select *operation_mode_select_{nullptr};
 
-  uint16_t char_handle_;
+  uint16_t char_handle_{0};
   std::vector<uint8_t> frame_buffer_;
   uint32_t last_frame_timestamp_ = 0;
 


### PR DESCRIPTION
## Summary

- `char_handle_` was declared without an initializer, leaving it with an indeterminate value from construction until the first BLE connection.
- Adds `{0}` in-class member initializer to guarantee a defined state at construction.