### PR TITLE
Fix venv cache miss, pin all actions to commit hashes

### DIFF
--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -28,7 +28,7 @@ runs:
         # yamllint disable-line rule:line-length
         key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ inputs.cache-key }}
     - name: Create Python virtual environment
-      if: steps.cache-venv.outputs.cache-hit != \'true\'
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       shell: bash
       run: |
         python -m venv venv

--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -17,17 +17,18 @@ runs:
   steps:
     - name: Set up Python ${{ inputs.python-version }}
       id: python
-      uses: actions/setup-python@v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: Restore Python virtual environment
       id: cache-venv
-      uses: actions/cache/restore@v5.0.4
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
       with:
         path: venv
         # yamllint disable-line rule:line-length
         key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ inputs.cache-key }}
     - name: Create Python virtual environment
+      if: steps.cache-venv.outputs.cache-hit != \'true\'
       shell: bash
       run: |
         python -m venv venv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
   yamllint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run yamllint
-        uses: frenck/action-yamllint@v1.5.0
+        uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47  # v1.5.0
         with:
           config: .yamllint
 
@@ -39,10 +39,10 @@ jobs:
       repo-hash: ${{ github.sha }}
     steps:
       - name: Check out this project
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Check out code from ESPHome project
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: esphome/esphome
           ref: dev
@@ -59,7 +59,7 @@ jobs:
           ln -sf ../venv venv
 
       - name: Archive prepared repository
-        uses: pyTooling/upload-artifact@v7
+        uses: pyTooling/upload-artifact@a59f191f676112c140f4330026bbb6ac19b7a44d  # v7
         with:
           name: bundle
           path: .
@@ -74,7 +74,7 @@ jobs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -86,12 +86,12 @@ jobs:
         run: echo key="${{ hashFiles('esphome/requirements.txt', 'esphome/requirements_test.txt') }}" >> $GITHUB_OUTPUT
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: venv
           # yamllint disable-line rule:line-length
@@ -118,7 +118,7 @@ jobs:
         working-directory: esphome
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -150,7 +150,7 @@ jobs:
         working-directory: esphome
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -181,7 +181,7 @@ jobs:
         working-directory: esphome
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -212,7 +212,7 @@ jobs:
         working-directory: esphome
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -243,7 +243,7 @@ jobs:
         working-directory: esphome
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -279,7 +279,7 @@ jobs:
         working-directory: esphome
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -312,8 +312,6 @@ jobs:
     defaults:
       run:
         working-directory: esphome
-    env:
-      GH_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -326,7 +324,7 @@ jobs:
 
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -341,7 +339,7 @@ jobs:
 
       - name: Cache platformio
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.platformio
           key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('esphome/platformio.ini') }}
@@ -349,7 +347,7 @@ jobs:
 
       - name: Cache platformio
         if: github.ref != 'refs/heads/main'
-        uses: actions/cache/restore@v5.0.4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.platformio
           key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('esphome/platformio.ini') }}
@@ -381,7 +379,7 @@ jobs:
       - common
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -405,7 +403,7 @@ jobs:
       - common
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -443,7 +441,7 @@ jobs:
       - common
     steps:
       - name: Download prepared repository
-        uses: pyTooling/download-artifact@v8
+        uses: pyTooling/download-artifact@dc575e4e9df4b6e3580712285f1c90f579bb8712  # v8
         with:
           name: bundle
           path: .
@@ -456,7 +454,7 @@ jobs:
 
       - name: Cache platformio
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.platformio
           key: platformio-compile-${{ hashFiles('esphome/platformio.ini') }}
@@ -464,7 +462,7 @@ jobs:
 
       - name: Cache platformio
         if: github.ref != 'refs/heads/main'
-        uses: actions/cache/restore@v5.0.4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.platformio
           key: platformio-compile-${{ hashFiles('esphome/platformio.ini') }}


### PR DESCRIPTION
## Summary

- Fix Python venv always being recreated even on cache hit (missing `if` guard in `restore-python` action)
- Pin all GitHub Actions to commit hashes for supply-chain security
- Update `actions/checkout` from v4.3.1 to v6.0.2
- Remove unused `GH_TOKEN` from `clang-tidy` job