### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/lumentree_ble/button/lumentree_button.cpp
+++ b/components/lumentree_ble/button/lumentree_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 static const char *const TAG = "lumentree_ble.button";
 
@@ -18,5 +17,4 @@ void LumentreeButton::press_action() {
   }
 }
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/button/lumentree_button.h
+++ b/components/lumentree_ble/button/lumentree_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 class LumentreeBle;
 class LumentreeButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class LumentreeButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/lumentree_ble.cpp
+++ b/components/lumentree_ble/lumentree_ble.cpp
@@ -11,8 +11,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 static const char *const TAG = "lumentree_ble";
 
@@ -762,7 +761,6 @@ std::string LumentreeBle::generate_device_model_(uint16_t device_type, uint16_t 
   return format_unknown_device(device_type, power_rating, light_engine ? 1 : 0);
 }
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble
 
 #endif

--- a/components/lumentree_ble/lumentree_ble.h
+++ b/components/lumentree_ble/lumentree_ble.h
@@ -15,8 +15,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -238,7 +237,6 @@ class LumentreeBle : public esphome::ble_client::BLEClientNode, public PollingCo
   std::string generate_device_model_(uint16_t device_type, uint16_t power_rating, bool light_engine);
 };
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble
 
 #endif

--- a/components/lumentree_ble/number/lumentree_number.cpp
+++ b/components/lumentree_ble/number/lumentree_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 static const char *const TAG = "lumentree_ble.number";
 
@@ -13,5 +12,4 @@ void LumentreeNumber::control(float value) {
   this->parent_->write_register(this->holding_register_, (uint16_t) (value / this->factor_));
 }
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/number/lumentree_number.h
+++ b/components/lumentree_ble/number/lumentree_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 class LumentreeBle;
 class LumentreeNumber : public number::Number, public Component {
@@ -26,5 +25,4 @@ class LumentreeNumber : public number::Number, public Component {
   uint8_t length_;
 };
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/select/lumentree_select.cpp
+++ b/components/lumentree_ble/select/lumentree_select.cpp
@@ -1,8 +1,7 @@
 #include "lumentree_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 static const char *const TAG = "lumentree_ble.select";
 
@@ -22,5 +21,4 @@ void LumentreeSelect::control(const std::string &value) {
   }
 }
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/select/lumentree_select.h
+++ b/components/lumentree_ble/select/lumentree_select.h
@@ -5,8 +5,7 @@
 #include "esphome/components/select/select.h"
 #include "../lumentree_ble.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 class LumentreeSelect : public select::Select, public Component {
  public:
@@ -23,5 +22,4 @@ class LumentreeSelect : public select::Select, public Component {
   std::map<std::string, uint16_t> option_mappings_;
 };
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/switch/lumentree_switch.cpp
+++ b/components/lumentree_ble/switch/lumentree_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 static const char *const TAG = "lumentree_ble.switch";
 
@@ -13,5 +12,4 @@ void LumentreeSwitch::write_state(bool state) {
   this->parent_->write_register(this->holding_register_, state ? 0x0001 : 0x0000);
 }
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble

--- a/components/lumentree_ble/switch/lumentree_switch.h
+++ b/components/lumentree_ble/switch/lumentree_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace lumentree_ble {
+namespace esphome::lumentree_ble {
 
 class LumentreeBle;
 class LumentreeSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class LumentreeSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace lumentree_ble
-}  // namespace esphome
+}  // namespace esphome::lumentree_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.