### PR TITLE
Rename SENSORS/BINARY_SENSORS to SENSOR_DEFS/BINARY_SENSOR_DEFS

### DIFF
--- a/components/lumentree_ble/binary_sensor.py
+++ b/components/lumentree_ble/binary_sensor.py
@@ -14,33 +14,33 @@ CONF_PV2_SUPPORT = "pv2_support"
 
 LumentreeBle = lumentree_ble_ns.class_("LumentreeBle")
 
-BINARY_SENSORS = {
-    CONF_GRID_CONNECTED: binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_CONNECTIVITY,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_BATTERY_CONNECTED: binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_CONNECTIVITY,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_PV2_SUPPORT: binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_CONNECTIVITY,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
+BINARY_SENSOR_DEFS = {
+    CONF_GRID_CONNECTED: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BATTERY_CONNECTED: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_PV2_SUPPORT: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
 }
 
 CONFIG_SCHEMA = LUMENTREE_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(sensor_name): sensor_config
-        for sensor_name, sensor_config in BINARY_SENSORS.items()
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_LUMENTREE_BLE_ID])
-    for sensor_name in BINARY_SENSORS:
-        if sensor_name in config:
-            conf = config[sensor_name]
+    for key in BINARY_SENSOR_DEFS:
+        if key in config:
+            conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)
-            cg.add(getattr(hub, f"set_{sensor_name}_binary_sensor")(sens))
+            cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/lumentree_ble/sensor.py
+++ b/components/lumentree_ble/sensor.py
@@ -247,7 +247,10 @@ SENSOR_DEFS = {
 }
 
 CONFIG_SCHEMA = LUMENTREE_BLE_COMPONENT_SCHEMA.extend(
-    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
+    {
+        cv.Optional(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
+    }
 )
 
 

--- a/components/lumentree_ble/sensor.py
+++ b/components/lumentree_ble/sensor.py
@@ -61,203 +61,200 @@ CONF_GRID_EXPORT = "grid_export"
 
 LumentreeBle = lumentree_ble_ns.class_("LumentreeBle")
 
-SENSORS = {
-    CONF_BATTERY_VOLTAGE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_VOLT,
-        accuracy_decimals=2,
-        device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_BATTERY_CURRENT: sensor.sensor_schema(
-        unit_of_measurement=UNIT_AMPERE,
-        accuracy_decimals=2,
-        device_class=DEVICE_CLASS_CURRENT,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_BATTERY_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_BATTERY_SOC: sensor.sensor_schema(
-        unit_of_measurement=UNIT_PERCENT,
-        accuracy_decimals=0,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_AC_OUTPUT_VOLTAGE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_VOLT,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_AC_INPUT_VOLTAGE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_VOLT,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_AC_OUTPUT_FREQUENCY: sensor.sensor_schema(
-        unit_of_measurement=UNIT_HERTZ,
-        accuracy_decimals=2,
-        device_class=DEVICE_CLASS_FREQUENCY,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_AC_INPUT_FREQUENCY: sensor.sensor_schema(
-        unit_of_measurement=UNIT_HERTZ,
-        accuracy_decimals=2,
-        device_class=DEVICE_CLASS_FREQUENCY,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_AC_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_PV_VOLTAGE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_VOLT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_PV_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_GRID_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_LOAD_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_DEVICE_TEMPERATURE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_PV2_VOLTAGE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_VOLT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_PV2_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_DEVICE_TYPE_IMAGE: sensor.sensor_schema(
-        accuracy_decimals=0,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_BATTERY_STATUS: sensor.sensor_schema(
-        accuracy_decimals=0,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_GRID_CONNECTION_STATUS: sensor.sensor_schema(
-        accuracy_decimals=0,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_DEVICE_TYPE: sensor.sensor_schema(
-        accuracy_decimals=0,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_DEVICE_POWER_RATING_CODE: sensor.sensor_schema(
-        accuracy_decimals=0,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_DEVICE_POWER_RATING: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    CONF_AC_OUTPUT_APPARENT_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_VOLT_AMPS,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_GRID_CT_POWER: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    CONF_TODAY_PV_PRODUCTION: sensor.sensor_schema(
-        unit_of_measurement=UNIT_KILOWATT_HOURS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    CONF_TODAY_ESSENTIAL_LOAD: sensor.sensor_schema(
-        unit_of_measurement=UNIT_KILOWATT_HOURS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    CONF_TODAY_TOTAL_CONSUMPTION: sensor.sensor_schema(
-        unit_of_measurement=UNIT_KILOWATT_HOURS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    CONF_TODAY_GRID_CONSUMPTION: sensor.sensor_schema(
-        unit_of_measurement=UNIT_KILOWATT_HOURS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    CONF_TODAY_BATTERY_CHARGING: sensor.sensor_schema(
-        unit_of_measurement=UNIT_KILOWATT_HOURS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    CONF_TODAY_BATTERY_DISCHARGE: sensor.sensor_schema(
-        unit_of_measurement=UNIT_KILOWATT_HOURS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    CONF_GRID_EXPORT: sensor.sensor_schema(
-        unit_of_measurement=UNIT_WATT,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
+SENSOR_DEFS = {
+    CONF_BATTERY_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_SOC: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AC_OUTPUT_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AC_INPUT_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AC_OUTPUT_FREQUENCY: {
+        "unit_of_measurement": UNIT_HERTZ,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_FREQUENCY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AC_INPUT_FREQUENCY: {
+        "unit_of_measurement": UNIT_HERTZ,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_FREQUENCY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AC_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PV_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PV_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_GRID_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_LOAD_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DEVICE_TEMPERATURE: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_PV2_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PV2_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DEVICE_TYPE_IMAGE: {
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BATTERY_STATUS: {
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_GRID_CONNECTION_STATUS: {
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DEVICE_TYPE: {
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DEVICE_POWER_RATING_CODE: {
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DEVICE_POWER_RATING: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_AC_OUTPUT_APPARENT_POWER: {
+        "unit_of_measurement": UNIT_VOLT_AMPS,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_GRID_CT_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_TODAY_PV_PRODUCTION: {
+        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TODAY_ESSENTIAL_LOAD: {
+        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TODAY_TOTAL_CONSUMPTION: {
+        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TODAY_GRID_CONSUMPTION: {
+        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TODAY_BATTERY_CHARGING: {
+        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TODAY_BATTERY_DISCHARGE: {
+        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_ENERGY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_GRID_EXPORT: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
 }
 
 CONFIG_SCHEMA = LUMENTREE_BLE_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(sensor_name): sensor_config
-        for sensor_name, sensor_config in SENSORS.items()
-    }
+    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_LUMENTREE_BLE_ID])
-    for sensor_name in SENSORS:
-        if sensor_name in config:
-            conf = config[sensor_name]
+    for key in SENSOR_DEFS:
+        if key in config:
+            conf = config[key]
             sens = await sensor.new_sensor(conf)
-            cg.add(getattr(hub, f"set_{sensor_name}_sensor")(sens))
+            cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -22,31 +22,39 @@ class TestHubConstants:
         assert hub.CONF_LUMENTREE_BLE_ID == "lumentree_ble_id"
 
 
-class TestSensorLists:
-    def test_sensors_completeness(self):
-        assert "battery_voltage" in sensor.SENSORS
-        assert "battery_current" in sensor.SENSORS
-        assert "battery_power" in sensor.SENSORS
-        assert "battery_soc" in sensor.SENSORS
-        assert "pv_voltage" in sensor.SENSORS
-        assert "pv_power" in sensor.SENSORS
-        assert "grid_power" in sensor.SENSORS
-        assert "load_power" in sensor.SENSORS
-        assert "device_temperature" in sensor.SENSORS
-        assert "today_pv_production" in sensor.SENSORS
-        assert len(sensor.SENSORS) == 31
+class TestSensorDefs:
+    def test_sensor_defs_completeness(self):
+        assert "battery_voltage" in sensor.SENSOR_DEFS
+        assert "battery_current" in sensor.SENSOR_DEFS
+        assert "battery_power" in sensor.SENSOR_DEFS
+        assert "battery_soc" in sensor.SENSOR_DEFS
+        assert "pv_voltage" in sensor.SENSOR_DEFS
+        assert "pv_power" in sensor.SENSOR_DEFS
+        assert "grid_power" in sensor.SENSOR_DEFS
+        assert "load_power" in sensor.SENSOR_DEFS
+        assert "device_temperature" in sensor.SENSOR_DEFS
+        assert "today_pv_production" in sensor.SENSOR_DEFS
+        assert len(sensor.SENSOR_DEFS) == 31
 
     def test_sensor_keys_are_strings(self):
-        for key in sensor.SENSORS:
+        for key in sensor.SENSOR_DEFS:
             assert isinstance(key, str)
 
+    def test_sensor_defs_values_are_dicts(self):
+        for key, kwargs in sensor.SENSOR_DEFS.items():
+            assert isinstance(kwargs, dict), f"{key} value must be a kwargs dict"
 
-class TestBinarySensorConstants:
-    def test_binary_sensors_dict(self):
-        assert binary_sensor.CONF_GRID_CONNECTED in binary_sensor.BINARY_SENSORS
-        assert binary_sensor.CONF_BATTERY_CONNECTED in binary_sensor.BINARY_SENSORS
-        assert binary_sensor.CONF_PV2_SUPPORT in binary_sensor.BINARY_SENSORS
-        assert len(binary_sensor.BINARY_SENSORS) == 3
+
+class TestBinarySensorDefs:
+    def test_binary_sensor_defs_completeness(self):
+        assert binary_sensor.CONF_GRID_CONNECTED in binary_sensor.BINARY_SENSOR_DEFS
+        assert binary_sensor.CONF_BATTERY_CONNECTED in binary_sensor.BINARY_SENSOR_DEFS
+        assert binary_sensor.CONF_PV2_SUPPORT in binary_sensor.BINARY_SENSOR_DEFS
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 3
+
+    def test_binary_sensor_defs_values_are_dicts(self):
+        for key, kwargs in binary_sensor.BINARY_SENSOR_DEFS.items():
+            assert isinstance(kwargs, dict), f"{key} value must be a kwargs dict"
 
 
 class TestTextSensorConstants:


### PR DESCRIPTION
## Summary

- Renames `SENSORS` → `SENSOR_DEFS` and `BINARY_SENSORS` → `BINARY_SENSOR_DEFS` in `lumentree_ble`
- Converts values from pre-built `sensor_schema()` / `binary_sensor_schema()` objects to raw kwargs dicts, matching the project-wide `SENSOR_DEFS` convention
- Both `CONFIG_SCHEMA` and `to_code` now iterate over the same dict, eliminating the possibility of a declared-but-unregistered sensor
- Updates `tests/test_component_schemas.py` to reference the new names and adds value-type assertions (`test_sensor_defs_values_are_dicts`)

## Test plan

- [ ] `pytest tests/test_component_schemas.py` passes
- [ ] All 31 sensors and 3 binary sensors remain available in YAML config