### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,7 +429,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ninverter0_mac_address: AA:BB:CC:DD:EE:FF" > secrets.yaml
           for YAML in esp*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -437,7 +437,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ninverter0_mac_address: AA:BB:CC:DD:EE:FF" > tests/secrets.yaml
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -507,7 +507,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ninverter0_mac_address: AA:BB:CC:DD:EE:FF" > secrets.yaml
           for YAML in esp*faker.yaml; do
             esphome -s external_components_source components compile $YAML
           done
@@ -517,7 +517,7 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ninverter0_mac_address: AA:BB:CC:DD:EE:FF" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ wifi_password: MY_WIFI_PASSWORD
 mqtt_host: MY_MQTT_HOST
 mqtt_username: MY_MQTT_USERNAME
 mqtt_password: MY_MQTT_PASSWORD
+
+# Required for the BLE example only. Use the MAC address of your Lumentree inverter.
+inverter0_mac_address: MY_INVERTER_MAC_ADDRESS
 EOF
 
 # Validate the configuration, create a binary, upload it, and start logs

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: lumentree-inverter
   device_description: "Monitor and control Lumentree solar inverter via BLE"
   external_components_source: github://syssi/esphome-lumentree@main
-  mac_address: "AA:BB:CC:DD:EE:FF"  # Replace with your inverter's MAC address
 
 esphome:
   name: ${name}
@@ -59,7 +58,7 @@ esp32_ble_tracker:
     active: true
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret inverter0_mac_address
     id: client0
 
 lumentree_ble:

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -6,4 +6,4 @@ else
   C="components"
 fi
 
-esphome -s mac_address 20:22:09:27:38:60 -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}
+esphome -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -28,7 +28,7 @@ api:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: "AA:BB:CC:DD:EE:FF"
+  - mac_address: !secret inverter0_mac_address
     id: client0
 
 lumentree_ble:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret inverter0_mac_address` directly in `ble_client:` instead of using a hard-coded YAML substitution
- Update CI to generate the required secret key (`inverter0_mac_address`) with an example value
- Document the new secret in the README installation section